### PR TITLE
Fix adults-only badge styling for mobile

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -25,7 +25,7 @@ const Footer = () => {
                 Un refugio de placer y sofisticación donde cada detalle está diseñado 
                 para despertar tus sentidos y crear experiencias inolvidables.
               </p>
-              <div className="adults-only-badge inline-block">
+              <div className="adults-only-badge">
                 Solo Adultos 18+
               </div>
             </div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -33,7 +33,7 @@ const Hero = () => {
       </div>
 
       {/* Adults Only Badge */}
-      <div className="absolute top-24 right-4 md:top-28 md:right-8 z-20">
+      <div className="absolute top-8 right-4 md:top-28 md:right-8 z-20">
         <motion.div
           initial={{ opacity: 0, x: 50 }}
           animate={{ opacity: 1, x: 0 }}

--- a/src/index.css
+++ b/src/index.css
@@ -75,6 +75,8 @@ body {
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
+  display: inline-block;
+  white-space: nowrap;
 }
 
 .section-padding {


### PR DESCRIPTION
## Summary
- prevent the "Solo Adultos 18+" badge from stretching or wrapping on small screens by making the badge inline and no-wrap
- clean up footer badge markup after centralizing badge styling
- move the badge higher in the hero section on mobile so it no longer overlaps the title

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899f0a221e88333b54cb39f372f8661